### PR TITLE
Fix to log nz_azconnector utility error on terminal 

### DIFF
--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -102,6 +102,7 @@ func parseArgs(conn *Conn, backupinfo *BackupInfo, othargs *OtherArgs) {
 
 func handleErrors(err error) {
     if err != nil {
+        fmt.Println(err)
         log.Fatalln(err)
     }
 }
@@ -239,7 +240,8 @@ func (cn *Conn) downloadBkp(outdir string, uniqueid string, blobpath string, str
                 }
                 if r.err != nil {
                     // stopping right here so that we
-                    // don't keep on uploading when one has failed
+                    // don't keep on downloading when one has failed
+                    fmt.Printf("%s: %v", r.blobname, r.err)
                     log.Fatalf("%s: %v", r.blobname, r.err)
                 }
                 filesdownloaded++ // this is fine, since this is single threaded increment
@@ -290,16 +292,15 @@ func (cn *Conn) downloadBkp(outdir string, uniqueid string, blobpath string, str
             }
         }
 
-        if blobfound > 0 {
+        if blobfound == 0 {
+            fmt.Println("No matching blob found. Please check if DB name, hostname, uniqueid or containername is correct")
             log.Println("No matching blob found. Please check if DB name, hostname, uniqueid or containername is correct")
             return fmt.Errorf("No matching blob found.")
-        }
-        if blobfound == 0 {
-            blobfound++
         }
     }
     close(work)
     <- done
+    fmt.Println("Total files downloaded:", filesdownloaded)
     log.Println("Total files downloaded:", filesdownloaded)
     return err
 }
@@ -384,6 +385,7 @@ func main() {
                         if r.err != nil {
                             // stopping right here so that we
                             // don't keep on uploading when one has failed
+                            fmt.Printf("%s: %v", r.job, r.err)
                             log.Fatalf("%s: %v", r.job, r.err)
                         }
                         filesuploaded++ // this is fine, since this is single threaded increment
@@ -404,6 +406,7 @@ func main() {
             close(work)
             <- done
             handleErrors(err)
+            fmt.Println("Upload successful. Total files uploaded:", filesuploaded)
             log.Println("Upload successful. Total files uploaded:", filesuploaded)
         }
 

--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -364,7 +364,7 @@ func main() {
             backupdir := filepath.Join(bkpdir, "Netezza", backupinfo.npshost, backupinfo.dbname, backupinfo.backupsetID)
             _, err = os.Stat(backupdir)
             if err != nil {
-                handleErrors(fmt.Errorf("Cannot access directory '%s': %v", backupdir, err))
+                handleErrors(fmt.Errorf("Cannot access directory '%s': %v. Please check if DB name, hostname are correct.", backupdir, err))
             }
 
             work := make(chan *uploadJob, othargs.paralleljobs)
@@ -421,7 +421,7 @@ func main() {
             close(work)
             <- done
             if err != nil {
-                handleErrors(fmt.Errorf("Error reading directory: %s: %v", backupdir, err))
+                handleErrors(fmt.Errorf("Error reading directory: %s: %v. Please check if DB name, hostname are correct.", backupdir, err))
             }
             log.Println("Upload successful. Total files uploaded:", filesuploaded)
         }


### PR DESCRIPTION
JIRA: https://github.com/IBM/netezza-utils/issues/7

Problem: Currently the utility writes all errors only to log file. On terminal, we do not know if it was successful or failed with error.

Solution: 
1. Added fmt.print to print error/message on terminal.
2. Fixed minor issue related to blob not found

Testing: Tried upload/download database backup from filesystem to cloud and vice versa. Tried with some invalid combination to produce errors. Logs present in JIRA.
