### PR TITLE
Change to restore cloud backup on nps

### DIFF
--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -350,7 +350,7 @@ func updateContents(arrContents []string){
         for i := 0 ; i < len(lines) ; i++ {
             line := lines[i]
             token := strings.Split(line, ",")
-            if ( strings.HasSuffix(token[len(token)-1],"0" ) ) {
+            if ( token[len(token)-1] == "0" ) {
                 r := []rune(line)
                 str := string(r[:len(r)-1]) + "1"
                 textline = append(textline,str)

--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -351,12 +351,9 @@ func updateContents(arrContents []string){
             line := lines[i]
             token := strings.Split(line, ",")
             if ( token[len(token)-1] == "0" ) {
-                r := []rune(line)
-                str := string(r[:len(r)-1]) + "1"
-                textline = append(textline,str)
-            } else {
-                textline = append(textline,line)
+                token[len(token)-1] = "1"
             }
+            textline = append(textline, strings.Join(token, ","))
         }
         output := strings.Join(textline, "\n")
         err = ioutil.WriteFile(contentFile, []byte(output), 0644)


### PR DESCRIPTION
Problem:  Backups taken to azure blob store should be restorable on-prem using filesystem connector when downloaded using the nz_azconnector utilities. 

    On Azure instance: Take backup of database using cloud connector ( -connector az)
    Use nz_s3connector or nz_azconnector to download the backup from cloud store to a on-prem NPS system.
    nzrestore -dir <dirname> should work.

Solution: Added flag "cloudBackup" , if this flag is used in download then location.txt and contents.txt will be override which will help to restore cloudbackup on nps

Testing: 
[nz_azDownloadRestore.txt](https://github.com/IBM/netezza-utils/files/6189266/nz_azDownloadRestore.txt)

