### PR TITLE
Fix for env var

### DIFF
--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -386,8 +386,38 @@ func main() {
     flag.Parse()
 
     if flag.NFlag() == 0 {
-        fmt.Println("No arguments passed to nz_azConnector. Below is the list of valid args:")
+	fmt.Println("No arguments passed to nz_azConnector. Below is the list of valid args:")
         flag.PrintDefaults()
+        os.Exit(1)
+    }
+    
+    requiredFlags := map[string]string{
+    	"db":              "NZ_DATABASE",
+    	"dir":             "NZ_DIR",
+    	"npshost":         "NZ_HOST",
+    	"storage-account": "",
+    	"key":             "",
+        "container":       "",
+        "backupset":       "",
+        "uniqueid":        "",
+    }
+ 
+    ensureDefault := func(f string, env string) bool {
+    	val := flag.Lookup(f).Value
+        if env != "" {
+        	if len(val.String()) == 0 && len(env) != 0 {
+                	val.Set(os.Getenv(env))
+                }
+        }
+        return len(val.String()) != 0
+    }
+ 
+    for f, env := range requiredFlags {
+    	if !ensureDefault(f, env) {
+        	fmt.Println("Did you miss '-' in any flag. If so Go treats remaining flags as the positional arguments")
+        	fmt.Fprintf(os.Stderr, "-%s is required\n", f)
+                os.Exit(1)
+        }
     }
 
     // log file configuration setup


### PR DESCRIPTION
Problem: nz_azConnector command was not returning error even when - was not passed to flag in command.

Solution: 1) If an user don't pass a value for a particular flag then it will error out an message. But for database,
directory and npshost flags the code will fetch the values from the environment variables even if the
user don't pass the value while running the command.
2) Code will print a proper message if user don't pass '-' to a particular flag. If user don't pass '-' to a flag
then Go language treats every argument after that particular flag as a positional argument.

Testing: 1) If user don't pass a value for db while running the command then the code will fetch the value as
"NZ_DATABASE" from the environment variables. Same for dir and npshost. Hence the code will run fine
even if the value for db, dir and npshost is not provided in the command.
2) In the command if user missed to pass '-' to storage-account then the code will consider remaining
command as a value for npshost. Hence the code will print a proper message showing that "Did you
miss '-' in any flag? If so Go treats remaining flags as the positional arguments".


