### PR TITLE
Improved BackupsetID logging

### DIFF
--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -413,6 +413,8 @@ func main() {
     log.Println("Nps hostname :", backupinfo.npshost)
     if backupinfo.backupsetID != "" {
         log.Println("BackupsetID :", backupinfo.backupsetID)
+    } else {
+        log.Println("BackupsetID : ALL")
     }
     log.Println("UniqueID :", othargs.uniqueid)
     log.Println("Number of files to upload/download in parallel :", othargs.paralleljobs)

--- a/bnr-utils/nz_azConnector/nz_azConnector.go
+++ b/bnr-utils/nz_azConnector/nz_azConnector.go
@@ -411,7 +411,9 @@ func main() {
     log.Println("Backup/Restore directory :",dirlist)
     log.Println("DB name :", backupinfo.dbname)
     log.Println("Nps hostname :", backupinfo.npshost)
-    log.Println("BackupsetID :", backupinfo.backupsetID)
+    if backupinfo.backupsetID != "" {
+        log.Println("BackupsetID :", backupinfo.backupsetID)
+    }
     log.Println("UniqueID :", othargs.uniqueid)
     log.Println("Number of files to upload/download in parallel :", othargs.paralleljobs)
 


### PR DESCRIPTION
**Problem:** The BackupsetID is not getting updated while uploading the DB on Azure Bucket under a specific condition.
**Conditon:** When the BackupsetID is not mentioned in the command, the log does not display the BackupsetID. IF BackupsetID is provided in the command, the log shows the BackupID, but if not provided, the BackupsetID remains empty.

**Solution:** Modified the code to conditionally display the BackupsetID in the log. This change ensures that the log only displays the BackupsetID when it is explicitly provided in the command, else it will display "BackupsetID : ALL" as all the backupsets present in the directory get uploaded when we don't specify BackupsetID.

**Testing:** Executed backup command with and without BackupsetID, verified the log and also ensured the backup was successfully uploaded to Azure.
