### PR TITLE
Remove hardcoded awscli-bundle version

### DIFF
--- a/bnr-utils/nz_s3Connector/nz_s3Connector
+++ b/bnr-utils/nz_s3Connector/nz_s3Connector
@@ -31,7 +31,7 @@ awscli_version_check()
         log_func "Aws cli installed on the host"
     else
         log_func "Aws cli not installed on the host. Installing aws cli now . . ."
-        unzip awscli-bundle-1.16.144.zip 2>/dev/null
+        unzip awscli-bundle-*.zip 2>/dev/null
         if [ $? -eq 0 ]; then
             log_func "Aws cli unzipped successfully. Now installing the aws cli"
             ./awscli-bundle/install -b ~/bin/aws 2>/dev/null


### PR DESCRIPTION
Problem: 
https://github.com/IBM/netezza-utils/blob/master/bnr-utils/nz_s3Connector/nz_s3Connector#L34
The awscli-bundle version was hardcoded.

Solution:
Replaced it with wild character * so it can accept if the bundle version is changed in future as well
awscli-bundle-*.zip

Testing:
```
[nz@sru1 nz_s3Connector]$ git diff 
diff --git a/bnr-utils/nz_s3Connector/nz_s3Connector b/bnr-utils/nz_s3Connector/nz_s3Connector
index 0f21c1d..5df33be 100644
--- a/bnr-utils/nz_s3Connector/nz_s3Connector
+++ b/bnr-utils/nz_s3Connector/nz_s3Connector
@@ -31,7 +31,7 @@ awscli_version_check()
         log_func "Aws cli installed on the host"
     else
         log_func "Aws cli not installed on the host. Installing aws cli now . . ."
-        unzip awscli-bundle-1.16.144.zip 2>/dev/null
+        unzip awscli-bundle-*.zip 2>/dev/null
         if [ $? -eq 0 ]; then
             log_func "Aws cli unzipped successfully. Now installing the aws cli"
             ./awscli-bundle/install -b ~/bin/aws 2>/dev/null
```
             
             
```
[nz@sru1 nz_s3Connector]$ ./nz_s3Connector -db DB2  -dir /tmp -connectorArgs  ACCESS_KEY_ID=AKIAYS5J24VE4H54MWFI:BUCKET_URL=concerto-bnr-test-qa:DEFAULT_REGION=us-east-2:SECRET_ACCESS_KEY=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:MULTIPART_SIZE_MB=4:UNIQUE_ID=ResumeBackup -upload -verbose -npshost sru1.fyre.ibm.com
[Fri Feb 14 00:08:34 PST 2025] : Checking if aws cli is installed on host or not
aws-cli/1.18.156 Python/3.6.8 Linux/4.18.0-477.27.1.el8_8.x86_64 botocore/1.18.15
[Fri Feb 14 00:08:34 PST 2025] : Aws cli installed on the host
[Fri Feb 14 00:08:34 PST 2025] : Reading connection arguments
[Fri Feb 14 00:08:34 PST 2025] : Setting aws environment variables based on connection arguments
[Fri Feb 14 00:08:35 PST 2025] : Executing aws command to connect to cloud
[Fri Feb 14 00:08:35 PST 2025] : Executing: aws  s3 cp '/tmp/Netezza/sru1.fyre.ibm.com/DB2/' 's3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/' --recursive
upload: ../../../../../../../tmp/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/data/200244.full.1.1 to s3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/data/200244.full.1.1
upload: ../../../../../../../tmp/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/contents.txt to s3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/contents.txt
upload: ../../../../../../../tmp/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/schema.xml to s3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/schema.xml
upload: ../../../../../../../tmp/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/data/data.marker to s3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/data/data.marker
upload: ../../../../../../../tmp/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/stream.0.1 to s3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/stream.0.1
upload: ../../../../../../../tmp/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/loc1/locations.txt to s3://concerto-bnr-test-qa/ResumeBackup/Netezza/sru1.fyre.ibm.com/DB2/20250214080732/1/FULL/md/loc1/locations.txt
```